### PR TITLE
Add skeleton for community engagement platform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,7 @@
+name := "CommunityEngagementPlatform"
+scalaVersion := "2.13.12"
+
+libraryDependencies ++= Seq(
+  "org.openjfx" % "javafx-controls" % "21" % "runtime",
+  "org.openjfx" % "javafx-fxml" % "21" % "runtime"
+)

--- a/src/main/resources/DashboardScene.fxml
+++ b/src/main/resources/DashboardScene.fxml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<VBox spacing="10" alignment="CENTER" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.controller.DashboardController">
+    <children>
+        <Label fx:id="welcomeLabel" text="Welcome" />
+        <Button fx:id="eventsButton" text="Events" onAction="#openEvents" />
+        <Button fx:id="forumButton" text="Forum" onAction="#openForum" />
+        <Button fx:id="resourcesButton" text="Resources" onAction="#openResources" />
+    </children>
+</VBox>

--- a/src/main/resources/EventScene.fxml
+++ b/src/main/resources/EventScene.fxml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<VBox spacing="10" alignment="CENTER" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.controller.EventController">
+    <children>
+        <TextField fx:id="titleField" promptText="Title" />
+        <TextArea fx:id="descriptionArea" promptText="Description" />
+        <TextField fx:id="dateField" promptText="YYYY-MM-DD" />
+        <Button fx:id="createButton" text="Create" onAction="#createEvent" />
+        <ListView fx:id="eventList" />
+    </children>
+</VBox>

--- a/src/main/resources/ForumScene.fxml
+++ b/src/main/resources/ForumScene.fxml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<VBox spacing="10" alignment="CENTER" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.controller.ForumController">
+    <children>
+        <TextField fx:id="threadField" promptText="Thread" />
+        <TextArea fx:id="contentArea" promptText="Content" />
+        <Button fx:id="postButton" text="Post" onAction="#addPost" />
+        <ListView fx:id="postList" />
+    </children>
+</VBox>

--- a/src/main/resources/LoginScene.fxml
+++ b/src/main/resources/LoginScene.fxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<VBox spacing="10" alignment="CENTER" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.controller.LoginController">
+    <children>
+        <TextField fx:id="emailField" promptText="Email" />
+        <PasswordField fx:id="passwordField" promptText="Password" />
+        <Button fx:id="loginButton" text="Login" onAction="#handleLogin" />
+    </children>
+</VBox>

--- a/src/main/resources/ResourceScene.fxml
+++ b/src/main/resources/ResourceScene.fxml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<VBox spacing="10" alignment="CENTER" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.controller.ResourceController">
+    <children>
+        <TextField fx:id="titleField" promptText="Title" />
+        <TextField fx:id="categoryField" promptText="Category" />
+        <Button fx:id="uploadButton" text="Upload" onAction="#uploadResource" />
+        <ListView fx:id="resourceList" />
+    </children>
+</VBox>

--- a/src/main/scala/community/MainApp.scala
+++ b/src/main/scala/community/MainApp.scala
@@ -1,0 +1,26 @@
+package community
+
+import javafx.application.Application
+import javafx.fxml.FXMLLoader
+import javafx.scene.Scene
+import javafx.stage.Stage
+
+/**
+ * Entry point for the Community Engagement Platform.
+ * Loads the login scene by default.
+ */
+class MainApp extends Application {
+  override def start(primaryStage: Stage): Unit = {
+    val loader = new FXMLLoader(getClass.getResource("/LoginScene.fxml"))
+    val scene = new Scene(loader.load())
+    primaryStage.setTitle("Community Engagement Platform")
+    primaryStage.setScene(scene)
+    primaryStage.show()
+  }
+}
+
+object MainApp {
+  def main(args: Array[String]): Unit = {
+    Application.launch(classOf[MainApp], args: _*)
+  }
+}

--- a/src/main/scala/community/controller/DashboardController.scala
+++ b/src/main/scala/community/controller/DashboardController.scala
@@ -1,0 +1,23 @@
+package community.controller
+
+import javafx.fxml.FXML
+import javafx.scene.control.{Button, Label}
+
+/**
+ * Controller for the main dashboard scene.
+ */
+class DashboardController {
+  @FXML private var welcomeLabel: Label = _
+  @FXML private var eventsButton: Button = _
+  @FXML private var forumButton: Button = _
+  @FXML private var resourcesButton: Button = _
+
+  @FXML
+  private def openEvents(): Unit = println("Open events scene")
+
+  @FXML
+  private def openForum(): Unit = println("Open forum scene")
+
+  @FXML
+  private def openResources(): Unit = println("Open resources scene")
+}

--- a/src/main/scala/community/controller/EventController.scala
+++ b/src/main/scala/community/controller/EventController.scala
@@ -1,0 +1,31 @@
+package community.controller
+
+import javafx.collections.FXCollections
+import javafx.fxml.FXML
+import javafx.scene.control.{Button, ListView, TextArea, TextField}
+import community.model.{Event, User}
+import java.time.LocalDate
+
+/**
+ * Controller for event management scene.
+ */
+class EventController {
+  private val events = FXCollections.observableArrayList[Event]()
+
+  @FXML private var titleField: TextField = _
+  @FXML private var descriptionArea: TextArea = _
+  @FXML private var dateField: TextField = _
+  @FXML private var createButton: Button = _
+  @FXML private var eventList: ListView[Event] = _
+
+  @FXML
+  private def createEvent(): Unit = {
+    val event = Event(titleField.getText, descriptionArea.getText, LocalDate.parse(dateField.getText), dummyUser)
+    events.add(event)
+    eventList.setItems(events)
+  }
+
+  private val dummyUser: User = new User("system", "system@example.com", "system") {
+    override def trackActivity(activity: String): Unit = ()
+  }
+}

--- a/src/main/scala/community/controller/ForumController.scala
+++ b/src/main/scala/community/controller/ForumController.scala
@@ -1,0 +1,34 @@
+package community.controller
+
+import javafx.collections.FXCollections
+import javafx.fxml.FXML
+import javafx.scene.control.{Button, ListView, TextArea, TextField}
+import community.model.{Forum, Post, User}
+import java.time.LocalDateTime
+
+/**
+ * Controller for community forum scene.
+ */
+class ForumController {
+  private val forum = new Forum
+  private val posts = FXCollections.observableArrayList[String]()
+
+  @FXML private var threadField: TextField = _
+  @FXML private var contentArea: TextArea = _
+  @FXML private var postButton: Button = _
+  @FXML private var postList: ListView[String] = _
+
+  @FXML
+  private def addPost(): Unit = {
+    val thread = threadField.getText
+    forum.createThread(thread)
+    val p = Post(dummyUser, contentArea.getText, LocalDateTime.now())
+    forum.addPost(thread, p)
+    posts.setAll(forum.getPosts(thread).map(_.content): _*)
+    postList.setItems(posts)
+  }
+
+  private val dummyUser: User = new User("system", "system@example.com", "system") {
+    override def trackActivity(activity: String): Unit = ()
+  }
+}

--- a/src/main/scala/community/controller/LoginController.scala
+++ b/src/main/scala/community/controller/LoginController.scala
@@ -1,0 +1,19 @@
+package community.controller
+
+import javafx.fxml.FXML
+import javafx.scene.control.{Button, PasswordField, TextField}
+
+/**
+ * Controller for the login scene.
+ */
+class LoginController {
+  @FXML private var emailField: TextField = _
+  @FXML private var passwordField: PasswordField = _
+  @FXML private var loginButton: Button = _
+
+  @FXML
+  private def handleLogin(): Unit = {
+    // Placeholder for login logic
+    println(s"Logging in: ${'$'}{emailField.getText}")
+  }
+}

--- a/src/main/scala/community/controller/ResourceController.scala
+++ b/src/main/scala/community/controller/ResourceController.scala
@@ -1,0 +1,30 @@
+package community.controller
+
+import javafx.collections.FXCollections
+import javafx.fxml.FXML
+import javafx.scene.control.{Button, ListView, TextField}
+import community.model.{Resource, User}
+import java.time.LocalDate
+
+/**
+ * Controller for resource sharing scene.
+ */
+class ResourceController {
+  private val resources = FXCollections.observableArrayList[Resource]()
+
+  @FXML private var titleField: TextField = _
+  @FXML private var categoryField: TextField = _
+  @FXML private var uploadButton: Button = _
+  @FXML private var resourceList: ListView[Resource] = _
+
+  @FXML
+  private def uploadResource(): Unit = {
+    val res = Resource(titleField.getText, categoryField.getText, LocalDate.now(), dummyUser)
+    resources.add(res)
+    resourceList.setItems(resources)
+  }
+
+  private val dummyUser: User = new User("system", "system@example.com", "system") {
+    override def trackActivity(activity: String): Unit = ()
+  }
+}

--- a/src/main/scala/community/model/CommunityLeader.scala
+++ b/src/main/scala/community/model/CommunityLeader.scala
@@ -1,0 +1,22 @@
+package community.model
+
+import community.util.{Notification, RoleManagement}
+
+/**
+ * Community leader with role management capabilities.
+ */
+class CommunityLeader(name: String, email: String)
+  extends User(name, email, "CommunityLeader")
+    with Notification with RoleManagement {
+
+  override def sendNotification(message: String): Unit =
+    println(s"Notification to $name: $message")
+
+  override def trackActivity(activity: String): Unit =
+    println(s"Community leader $name activity: $activity")
+
+  override def assignRole(user: User, role: String): Unit = {
+    user.role = role
+    println(s"$name assigned role '$role' to ${user.name}")
+  }
+}

--- a/src/main/scala/community/model/Event.scala
+++ b/src/main/scala/community/model/Event.scala
@@ -1,0 +1,17 @@
+package community.model
+
+import java.time.LocalDate
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Represents a community event.
+ */
+case class Event(
+  title: String,
+  description: String,
+  date: LocalDate,
+  organizer: User,
+  participants: ListBuffer[User] = ListBuffer.empty
+) {
+  def addParticipant(user: User): Unit = participants += user
+}

--- a/src/main/scala/community/model/Farmer.scala
+++ b/src/main/scala/community/model/Farmer.scala
@@ -1,0 +1,16 @@
+package community.model
+
+import community.util.Notification
+
+/**
+ * Farmer user of the platform.
+ */
+class Farmer(name: String, email: String)
+  extends User(name, email, "Farmer") with Notification {
+
+  override def sendNotification(message: String): Unit =
+    println(s"Notification to $name: $message")
+
+  override def trackActivity(activity: String): Unit =
+    println(s"Farmer $name activity: $activity")
+}

--- a/src/main/scala/community/model/Forum.scala
+++ b/src/main/scala/community/model/Forum.scala
@@ -1,0 +1,22 @@
+package community.model
+
+import java.time.LocalDateTime
+import scala.collection.mutable.{ListBuffer, Map}
+
+/**
+ * Simple forum for discussion threads.
+ */
+case class Post(author: User, content: String, date: LocalDateTime = LocalDateTime.now())
+
+class Forum {
+  private val threads = Map.empty[String, ListBuffer[Post]]
+
+  def createThread(title: String): Unit =
+    threads.getOrElseUpdate(title, ListBuffer.empty)
+
+  def addPost(thread: String, post: Post): Unit =
+    threads.get(thread).foreach(_ += post)
+
+  def getPosts(thread: String): List[Post] =
+    threads.get(thread).map(_.toList).getOrElse(Nil)
+}

--- a/src/main/scala/community/model/Resource.scala
+++ b/src/main/scala/community/model/Resource.scala
@@ -1,0 +1,13 @@
+package community.model
+
+import java.time.LocalDate
+
+/**
+ * Educational resource uploaded to the platform.
+ */
+case class Resource(
+  title: String,
+  category: String,
+  uploadDate: LocalDate,
+  uploader: User
+)

--- a/src/main/scala/community/model/User.scala
+++ b/src/main/scala/community/model/User.scala
@@ -1,0 +1,13 @@
+package community.model
+
+import community.util.Trackable
+
+/**
+ * Base abstract user in the system.
+ * @param name user's full name
+ * @param email contact email
+ * @param role role identifier for permissions
+ */
+abstract class User(var name: String, var email: String, var role: String) extends Trackable {
+  def displayInfo(): String = s"$name ($role)"
+}

--- a/src/main/scala/community/model/Volunteer.scala
+++ b/src/main/scala/community/model/Volunteer.scala
@@ -1,0 +1,16 @@
+package community.model
+
+import community.util.Notification
+
+/**
+ * Volunteer user of the platform.
+ */
+class Volunteer(name: String, email: String)
+  extends User(name, email, "Volunteer") with Notification {
+
+  override def sendNotification(message: String): Unit =
+    println(s"Notification to $name: $message")
+
+  override def trackActivity(activity: String): Unit =
+    println(s"Volunteer $name activity: $activity")
+}

--- a/src/main/scala/community/util/Notification.scala
+++ b/src/main/scala/community/util/Notification.scala
@@ -1,0 +1,8 @@
+package community.util
+
+/**
+ * Notification capability for delivering messages to users.
+ */
+trait Notification {
+  def sendNotification(message: String): Unit
+}

--- a/src/main/scala/community/util/RoleManagement.scala
+++ b/src/main/scala/community/util/RoleManagement.scala
@@ -1,0 +1,10 @@
+package community.util
+
+import community.model.User
+
+/**
+ * Trait for assigning roles and managing permissions.
+ */
+trait RoleManagement {
+  def assignRole(user: User, role: String): Unit
+}

--- a/src/main/scala/community/util/Trackable.scala
+++ b/src/main/scala/community/util/Trackable.scala
@@ -1,0 +1,12 @@
+package community.util
+
+/**
+ * Trait for tracking user activity within the platform.
+ */
+trait Trackable {
+  /**
+   * Track a user activity description.
+   * @param activity description of the action performed
+   */
+  def trackActivity(activity: String): Unit
+}


### PR DESCRIPTION
## Summary
- set up sbt build with JavaFX dependencies
- scaffold JavaFX entry point, controllers, and FXML views for login, dashboard, events, forum, and resources
- implement core domain models and traits for users, events, resources, notifications, role management, and forum threads

## Testing
- `scalac $(find src/main/scala -name '*.scala')` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68912920d3d88327ad0ad39e6482a41e