### PR TITLE
Add Scala prototype for community engagement platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# OOP-
-oop project 
+# Community Engagement Platform Prototype
+
+This project is a minimal Scala/JavaFX prototype showcasing a community engagement platform for sustainable agriculture. It demonstrates an object-oriented design with basic user roles, event management, resource sharing, and forum interactions.
+
+## Project Structure
+- `src/main/scala/community` – Scala sources for domain models and controllers
+- `src/main/resources` – FXML views for JavaFX scenes
+- `build.sbt` – Build definition
+
+## Running
+An [sbt](https://www.scala-sbt.org/) build definition is provided, but Scala/JavaFX are not installed in this environment. To run locally:
+
+```bash
+sbt run
+```
+
+This will launch the JavaFX application starting at the login screen.

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,6 @@
+ThisBuild / scalaVersion := "2.13.12"
+
+libraryDependencies ++= Seq(
+  "org.openjfx" % "javafx-controls" % "21.0.2",
+  "org.openjfx" % "javafx-fxml" % "21.0.2"
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.7

--- a/src/main/resources/dashboard.fxml
+++ b/src/main/resources/dashboard.fxml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<VBox prefWidth="400" prefHeight="300" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.DashboardController">
+  <children>
+    <Label text="Dashboard"/>
+  </children>
+</VBox>

--- a/src/main/resources/events.fxml
+++ b/src/main/resources/events.fxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<VBox prefWidth="400" prefHeight="300" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.EventController">
+  <children>
+    <Label text="Events"/>
+    <TextField fx:id="titleField" promptText="Event Title"/>
+    <Button text="Create" onAction="#createEvent"/>
+  </children>
+</VBox>

--- a/src/main/resources/forum.fxml
+++ b/src/main/resources/forum.fxml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<VBox prefWidth="400" prefHeight="300" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.ForumController">
+  <children>
+    <Label text="Forum"/>
+    <Button text="New Thread" onAction="#newThread"/>
+  </children>
+</VBox>

--- a/src/main/resources/login.fxml
+++ b/src/main/resources/login.fxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.control.*?>
+<AnchorPane prefWidth="300" prefHeight="200" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.LoginController">
+  <children>
+    <Label layoutX="20" layoutY="20" text="Email"/>
+    <TextField fx:id="emailField" layoutX="80" layoutY="20"/>
+    <Button layoutX="80" layoutY="60" text="Login" onAction="#handleLogin"/>
+  </children>
+</AnchorPane>

--- a/src/main/resources/resources.fxml
+++ b/src/main/resources/resources.fxml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.*?>
+<VBox prefWidth="400" prefHeight="300" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.ResourceController">
+  <children>
+    <Label text="Resources"/>
+    <TextField fx:id="titleField" promptText="Title"/>
+    <Button text="Upload" onAction="#uploadResource"/>
+  </children>
+</VBox>

--- a/src/main/scala/community/CommunityLeader.scala
+++ b/src/main/scala/community/CommunityLeader.scala
@@ -1,0 +1,7 @@
+package community
+
+class CommunityLeader(name: String, email: String)
+    extends User(name, email, CommunityLeaderRole) {
+  override def trackActivity(activity: String): Unit =
+    println(s"Leader $name activity: $activity")
+}

--- a/src/main/scala/community/DashboardController.scala
+++ b/src/main/scala/community/DashboardController.scala
@@ -1,0 +1,10 @@
+package community
+
+import javafx.fxml.FXML
+
+class DashboardController {
+  @FXML
+  def initialize(): Unit = {
+    println("Dashboard loaded")
+  }
+}

--- a/src/main/scala/community/Event.scala
+++ b/src/main/scala/community/Event.scala
@@ -1,0 +1,18 @@
+package community
+
+import java.time.LocalDate
+import scala.collection.mutable.ListBuffer
+
+case class Event(
+    title: String,
+    description: String,
+    date: LocalDate,
+    organizer: User,
+    participants: ListBuffer[User] = ListBuffer.empty
+) extends Notification {
+
+  def addParticipant(user: User): Unit = participants += user
+
+  override def sendNotification(message: String): Unit =
+    println(s"[Event: $title] $message")
+}

--- a/src/main/scala/community/EventController.scala
+++ b/src/main/scala/community/EventController.scala
@@ -1,0 +1,15 @@
+package community
+
+import javafx.fxml.FXML
+import javafx.scene.control.TextField
+import java.time.LocalDate
+
+class EventController {
+  @FXML private var titleField: TextField = _
+
+  @FXML
+  def createEvent(): Unit = {
+    val event = Event(titleField.getText, "", LocalDate.now, new CommunityLeader("Admin", "admin@example.com"))
+    println(s"Created event: ${'$'}{event.title}")
+  }
+}

--- a/src/main/scala/community/Farmer.scala
+++ b/src/main/scala/community/Farmer.scala
@@ -1,0 +1,7 @@
+package community
+
+class Farmer(name: String, email: String)
+    extends User(name, email, FarmerRole) {
+  override def trackActivity(activity: String): Unit =
+    println(s"Farmer $name activity: $activity")
+}

--- a/src/main/scala/community/Forum.scala
+++ b/src/main/scala/community/Forum.scala
@@ -1,0 +1,21 @@
+package community
+
+import scala.collection.mutable.{ListBuffer, Buffer}
+
+class Forum {
+  case class Post(author: User, content: String)
+  case class Thread(title: String, posts: Buffer[Post] = ListBuffer.empty)
+
+  private val threads: Buffer[Thread] = ListBuffer.empty
+
+  def createThread(title: String): Thread = {
+    val thread = Thread(title)
+    threads += thread
+    thread
+  }
+
+  def addPost(thread: Thread, author: User, content: String): Unit =
+    thread.posts += Post(author, content)
+
+  def allThreads: Seq[Thread] = threads.toSeq
+}

--- a/src/main/scala/community/ForumController.scala
+++ b/src/main/scala/community/ForumController.scala
@@ -1,0 +1,13 @@
+package community
+
+import javafx.fxml.FXML
+
+class ForumController {
+  private val forum = new Forum
+
+  @FXML
+  def newThread(): Unit = {
+    forum.createThread("General Discussion")
+    println("Thread created")
+  }
+}

--- a/src/main/scala/community/LoginController.scala
+++ b/src/main/scala/community/LoginController.scala
@@ -1,0 +1,13 @@
+package community
+
+import javafx.fxml.FXML
+import javafx.scene.control.TextField
+
+class LoginController {
+  @FXML private var emailField: TextField = _
+
+  @FXML
+  def handleLogin(): Unit = {
+    println(s"Login attempt for ${'$'}{emailField.getText}")
+  }
+}

--- a/src/main/scala/community/MainApp.scala
+++ b/src/main/scala/community/MainApp.scala
@@ -1,0 +1,22 @@
+package community
+
+import javafx.application.Application
+import javafx.fxml.FXMLLoader
+import javafx.scene.Scene
+import javafx.stage.Stage
+
+class MainApp extends Application {
+  override def start(stage: Stage): Unit = {
+    val loader = new FXMLLoader(getClass.getResource("/login.fxml"))
+    val scene = new Scene(loader.load())
+    stage.setScene(scene)
+    stage.setTitle("Community Engagement Platform")
+    stage.show()
+  }
+}
+
+object MainApp {
+  def main(args: Array[String]): Unit = {
+    Application.launch(classOf[MainApp], args: _*)
+  }
+}

--- a/src/main/scala/community/Notification.scala
+++ b/src/main/scala/community/Notification.scala
@@ -1,0 +1,5 @@
+package community
+
+trait Notification {
+  def sendNotification(message: String): Unit
+}

--- a/src/main/scala/community/Resource.scala
+++ b/src/main/scala/community/Resource.scala
@@ -1,0 +1,14 @@
+package community
+
+import java.time.LocalDate
+
+case class Resource(
+    title: String,
+    category: String,
+    uploadDate: LocalDate,
+    uploader: User
+) extends Notification {
+
+  override def sendNotification(message: String): Unit =
+    println(s"[Resource: $title] $message")
+}

--- a/src/main/scala/community/ResourceController.scala
+++ b/src/main/scala/community/ResourceController.scala
@@ -1,0 +1,15 @@
+package community
+
+import javafx.fxml.FXML
+import javafx.scene.control.TextField
+import java.time.LocalDate
+
+class ResourceController {
+  @FXML private var titleField: TextField = _
+
+  @FXML
+  def uploadResource(): Unit = {
+    val resource = Resource(titleField.getText, "General", LocalDate.now, new Volunteer("Uploader", "uploader@example.com"))
+    println(s"Uploaded resource: ${'$'}{resource.title}")
+  }
+}

--- a/src/main/scala/community/Role.scala
+++ b/src/main/scala/community/Role.scala
@@ -1,0 +1,6 @@
+package community
+
+sealed trait Role { def name: String }
+case object FarmerRole extends Role { val name = "Farmer" }
+case object VolunteerRole extends Role { val name = "Volunteer" }
+case object CommunityLeaderRole extends Role { val name = "Community Leader" }

--- a/src/main/scala/community/RoleManagement.scala
+++ b/src/main/scala/community/RoleManagement.scala
@@ -1,0 +1,5 @@
+package community
+
+trait RoleManagement {
+  def assignRole(role: Role): Unit
+}

--- a/src/main/scala/community/Trackable.scala
+++ b/src/main/scala/community/Trackable.scala
@@ -1,0 +1,5 @@
+package community
+
+trait Trackable {
+  def trackActivity(activity: String): Unit
+}

--- a/src/main/scala/community/User.scala
+++ b/src/main/scala/community/User.scala
@@ -1,0 +1,12 @@
+package community
+
+abstract class User(val name: String, val email: String, private var _role: Role)
+    extends Trackable
+    with RoleManagement {
+
+  def role: Role = _role
+
+  override def assignRole(role: Role): Unit = {
+    _role = role
+  }
+}

--- a/src/main/scala/community/Volunteer.scala
+++ b/src/main/scala/community/Volunteer.scala
@@ -1,0 +1,7 @@
+package community
+
+class Volunteer(name: String, email: String)
+    extends User(name, email, VolunteerRole) {
+  override def trackActivity(activity: String): Unit =
+    println(s"Volunteer $name activity: $activity")
+}


### PR DESCRIPTION
## Summary
- scaffold minimal Scala/JavaFX prototype for a community engagement platform
- implement core models (users, events, resources, forum) with basic notifications
- add FXML views and controllers for login, dashboard, events, forum, and resources

## Testing
- `sbt compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68912920d3d88327ad0ad39e6482a41e