### PR TITLE
Add navigation, basic CRUD, and activity tracking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,5 +2,6 @@ ThisBuild / scalaVersion := "2.13.12"
 
 libraryDependencies ++= Seq(
   "org.openjfx" % "javafx-controls" % "21.0.2",
-  "org.openjfx" % "javafx-fxml" % "21.0.2"
+  "org.openjfx" % "javafx-fxml" % "21.0.2",
+  "org.xerial" % "sqlite-jdbc" % "3.42.0.0"
 )

--- a/src/main/resources/dashboard.fxml
+++ b/src/main/resources/dashboard.fxml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.*?>
-<VBox prefWidth="400" prefHeight="300" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.DashboardController">
+<VBox fx:id="rootPane" prefWidth="400" prefHeight="300" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.DashboardController">
   <children>
     <Label text="Dashboard"/>
+    <Button text="Events" onAction="#goToEvents"/>
+    <Button text="Forum" onAction="#goToForum"/>
+    <Button text="Resources" onAction="#goToResources"/>
   </children>
 </VBox>

--- a/src/main/resources/events.fxml
+++ b/src/main/resources/events.fxml
@@ -6,5 +6,8 @@
     <Label text="Events"/>
     <TextField fx:id="titleField" promptText="Event Title"/>
     <Button text="Create" onAction="#createEvent"/>
+    <ListView fx:id="eventsList"/>
+    <Button text="Delete Selected" onAction="#deleteEvent"/>
+    <Button text="Back" onAction="#backToDashboard"/>
   </children>
 </VBox>

--- a/src/main/resources/forum.fxml
+++ b/src/main/resources/forum.fxml
@@ -5,5 +5,8 @@
   <children>
     <Label text="Forum"/>
     <Button text="New Thread" onAction="#newThread"/>
+    <ListView fx:id="threadsList"/>
+    <Button text="Delete Selected" onAction="#deleteThread"/>
+    <Button text="Back" onAction="#backToDashboard"/>
   </children>
 </VBox>

--- a/src/main/resources/resources.fxml
+++ b/src/main/resources/resources.fxml
@@ -6,5 +6,8 @@
     <Label text="Resources"/>
     <TextField fx:id="titleField" promptText="Title"/>
     <Button text="Upload" onAction="#uploadResource"/>
+    <ListView fx:id="resourcesList"/>
+    <Button text="Delete Selected" onAction="#deleteResource"/>
+    <Button text="Back" onAction="#backToDashboard"/>
   </children>
 </VBox>

--- a/src/main/scala/community/DashboardController.scala
+++ b/src/main/scala/community/DashboardController.scala
@@ -1,10 +1,31 @@
 package community
 
-import javafx.fxml.FXML
+import javafx.fxml.{FXML, FXMLLoader}
+import javafx.scene.Scene
+import javafx.scene.layout.VBox
+import javafx.stage.Stage
 
 class DashboardController {
+  @FXML private var rootPane: VBox = _
+
   @FXML
   def initialize(): Unit = {
     println("Dashboard loaded")
   }
+
+  private def switchScene(fxml: String, activity: String): Unit = {
+    val stage = rootPane.getScene.getWindow.asInstanceOf[Stage]
+    val root = FXMLLoader.load(getClass.getResource(fxml))
+    stage.setScene(new Scene(root))
+    Session.currentUser.foreach(_.trackActivity(activity))
+  }
+
+  @FXML def goToEvents(): Unit =
+    if (Session.currentUser.exists(_.role == CommunityLeaderRole))
+      switchScene("/events.fxml", "navigate events")
+    else
+      println("Access denied")
+
+  @FXML def goToForum(): Unit = switchScene("/forum.fxml", "navigate forum")
+  @FXML def goToResources(): Unit = switchScene("/resources.fxml", "navigate resources")
 }

--- a/src/main/scala/community/EventController.scala
+++ b/src/main/scala/community/EventController.scala
@@ -1,15 +1,42 @@
 package community
 
-import javafx.fxml.FXML
-import javafx.scene.control.TextField
+import javafx.fxml.{FXML, FXMLLoader}
+import javafx.scene.Scene
+import javafx.scene.control.{ListView, TextField}
 import java.time.LocalDate
+import javafx.stage.Stage
+import scala.collection.mutable.ListBuffer
 
 class EventController {
   @FXML private var titleField: TextField = _
+  @FXML private var eventsList: ListView[String] = _
+
+  private val events = ListBuffer.empty[Event]
 
   @FXML
   def createEvent(): Unit = {
-    val event = Event(titleField.getText, "", LocalDate.now, new CommunityLeader("Admin", "admin@example.com"))
-    println(s"Created event: ${'$'}{event.title}")
+    val organizer = Session.currentUser.getOrElse(new CommunityLeader("Admin", "admin@example.com"))
+    val event = Event(titleField.getText, "", LocalDate.now, organizer)
+    events += event
+    eventsList.getItems.add(event.title)
+    event.sendNotification("Event created")
+    organizer.trackActivity("created event")
+  }
+
+  @FXML
+  def deleteEvent(): Unit = {
+    val index = eventsList.getSelectionModel.getSelectedIndex
+    if (index >= 0) {
+      events.remove(index)
+      eventsList.getItems.remove(index)
+    }
+  }
+
+  @FXML
+  def backToDashboard(): Unit = {
+    val stage = eventsList.getScene.getWindow.asInstanceOf[Stage]
+    val root = FXMLLoader.load(getClass.getResource("/dashboard.fxml"))
+    stage.setScene(new Scene(root))
+    Session.currentUser.foreach(_.trackActivity("back to dashboard"))
   }
 }

--- a/src/main/scala/community/Forum.scala
+++ b/src/main/scala/community/Forum.scala
@@ -14,6 +14,8 @@ class Forum {
     thread
   }
 
+  def removeThread(thread: Thread): Unit = threads -= thread
+
   def addPost(thread: Thread, author: User, content: String): Unit =
     thread.posts += Post(author, content)
 

--- a/src/main/scala/community/ForumController.scala
+++ b/src/main/scala/community/ForumController.scala
@@ -1,13 +1,37 @@
 package community
 
-import javafx.fxml.FXML
+import javafx.fxml.{FXML, FXMLLoader}
+import javafx.scene.Scene
+import javafx.scene.control.ListView
+import javafx.stage.Stage
 
 class ForumController {
   private val forum = new Forum
+  @FXML private var threadsList: ListView[String] = _
 
   @FXML
   def newThread(): Unit = {
-    forum.createThread("General Discussion")
+    val thread = forum.createThread("General Discussion")
+    threadsList.getItems.add(thread.title)
+    Session.currentUser.foreach(_.trackActivity("created thread"))
     println("Thread created")
+  }
+
+  @FXML
+  def deleteThread(): Unit = {
+    val index = threadsList.getSelectionModel.getSelectedIndex
+    if (index >= 0) {
+      val thread = forum.allThreads(index)
+      forum.removeThread(thread)
+      threadsList.getItems.remove(index)
+    }
+  }
+
+  @FXML
+  def backToDashboard(): Unit = {
+    val stage = threadsList.getScene.getWindow.asInstanceOf[Stage]
+    val root = FXMLLoader.load(getClass.getResource("/dashboard.fxml"))
+    stage.setScene(new Scene(root))
+    Session.currentUser.foreach(_.trackActivity("back to dashboard"))
   }
 }

--- a/src/main/scala/community/LoginController.scala
+++ b/src/main/scala/community/LoginController.scala
@@ -2,12 +2,31 @@ package community
 
 import javafx.fxml.FXML
 import javafx.scene.control.TextField
+import javafx.fxml.FXMLLoader
+import javafx.scene.Scene
+import javafx.stage.Stage
 
 class LoginController {
   @FXML private var emailField: TextField = _
 
+  private val users: Map[String, User] = Map(
+    "farmer@example.com" -> new Farmer("Farmer Joe", "farmer@example.com"),
+    "volunteer@example.com" -> new Volunteer("Volunteer Bob", "volunteer@example.com"),
+    "leader@example.com" -> new CommunityLeader("Leader Alice", "leader@example.com")
+  )
+
   @FXML
   def handleLogin(): Unit = {
-    println(s"Login attempt for ${'$'}{emailField.getText}")
+    val email = emailField.getText
+    users.get(email) match {
+      case Some(user) =>
+        Session.currentUser = Some(user)
+        user.trackActivity("login")
+        val stage = emailField.getScene.getWindow.asInstanceOf[Stage]
+        val root = FXMLLoader.load(getClass.getResource("/dashboard.fxml"))
+        stage.setScene(new Scene(root))
+      case None =>
+        println("Invalid user")
+    }
   }
 }

--- a/src/main/scala/community/ResourceController.scala
+++ b/src/main/scala/community/ResourceController.scala
@@ -1,15 +1,42 @@
 package community
 
-import javafx.fxml.FXML
-import javafx.scene.control.TextField
+import javafx.fxml.{FXML, FXMLLoader}
+import javafx.scene.Scene
+import javafx.scene.control.{ListView, TextField}
 import java.time.LocalDate
+import javafx.stage.Stage
+import scala.collection.mutable.ListBuffer
 
 class ResourceController {
   @FXML private var titleField: TextField = _
+  @FXML private var resourcesList: ListView[String] = _
+
+  private val resources = ListBuffer.empty[Resource]
 
   @FXML
   def uploadResource(): Unit = {
-    val resource = Resource(titleField.getText, "General", LocalDate.now, new Volunteer("Uploader", "uploader@example.com"))
-    println(s"Uploaded resource: ${'$'}{resource.title}")
+    val uploader = Session.currentUser.getOrElse(new Volunteer("Uploader", "uploader@example.com"))
+    val resource = Resource(titleField.getText, "General", LocalDate.now, uploader)
+    resources += resource
+    resourcesList.getItems.add(resource.title)
+    resource.sendNotification("Resource uploaded")
+    uploader.trackActivity("uploaded resource")
+  }
+
+  @FXML
+  def deleteResource(): Unit = {
+    val index = resourcesList.getSelectionModel.getSelectedIndex
+    if (index >= 0) {
+      resources.remove(index)
+      resourcesList.getItems.remove(index)
+    }
+  }
+
+  @FXML
+  def backToDashboard(): Unit = {
+    val stage = resourcesList.getScene.getWindow.asInstanceOf[Stage]
+    val root = FXMLLoader.load(getClass.getResource("/dashboard.fxml"))
+    stage.setScene(new Scene(root))
+    Session.currentUser.foreach(_.trackActivity("back to dashboard"))
   }
 }

--- a/src/main/scala/community/Session.scala
+++ b/src/main/scala/community/Session.scala
@@ -1,0 +1,5 @@
+package community
+
+object Session {
+  var currentUser: Option[User] = None
+}


### PR DESCRIPTION
## Summary
- integrate SQLite JDBC dependency and session tracking for authentication
- implement dashboard navigation with role checks plus in-memory CRUD for events, resources, and forum threads
- wire FXML scenes to controllers, add notifications and activity tracking on user actions

## Testing
- `sbt test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68912920d3d88327ad0ad39e6482a41e