### PR TITLE
Add signup feature and basic styling

### DIFF
--- a/src/main/resources/login.fxml
+++ b/src/main/resources/login.fxml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.control.*?>
-<AnchorPane prefWidth="300" prefHeight="200" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.LoginController">
+<AnchorPane stylesheets="@styles.css" prefWidth="300" prefHeight="200" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.LoginController">
   <children>
     <Label layoutX="20" layoutY="20" text="Email"/>
     <TextField fx:id="emailField" layoutX="80" layoutY="20"/>
     <Button layoutX="80" layoutY="60" text="Login" onAction="#handleLogin"/>
+    <Button layoutX="140" layoutY="60" text="Sign Up" onAction="#handleShowSignup"/>
   </children>
 </AnchorPane>

--- a/src/main/resources/signup.fxml
+++ b/src/main/resources/signup.fxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.control.*?>
+<AnchorPane stylesheets="@styles.css" prefWidth="300" prefHeight="220" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml" fx:controller="community.SignupController">
+  <children>
+    <Label layoutX="20" layoutY="20" text="Name"/>
+    <TextField fx:id="nameField" layoutX="80" layoutY="20"/>
+    <Label layoutX="20" layoutY="60" text="Email"/>
+    <TextField fx:id="emailField" layoutX="80" layoutY="60"/>
+    <Button layoutX="80" layoutY="100" text="Sign Up" onAction="#handleSignup"/>
+    <Button layoutX="150" layoutY="100" text="Back" onAction="#handleBack"/>
+  </children>
+</AnchorPane>

--- a/src/main/resources/signup.html
+++ b/src/main/resources/signup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="web.css">
+  <title>Sign Up</title>
+</head>
+<body>
+  <h2>Sign Up</h2>
+  <form>
+    <label for="name">Name</label>
+    <input type="text" id="name" name="name">
+    <label for="email">Email</label>
+    <input type="email" id="email" name="email">
+    <button type="submit">Sign Up</button>
+  </form>
+</body>
+</html>

--- a/src/main/resources/styles.css
+++ b/src/main/resources/styles.css
@@ -1,0 +1,13 @@
+.root {
+  -fx-font-family: "Arial";
+}
+
+.button {
+  -fx-background-color: #4CAF50;
+  -fx-text-fill: white;
+}
+
+.text-field {
+  -fx-background-color: #f0f0f0;
+  -fx-border-color: #ccc;
+}

--- a/src/main/resources/web.css
+++ b/src/main/resources/web.css
@@ -1,0 +1,22 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+label {
+  display: block;
+  margin-top: 10px;
+}
+
+input {
+  margin-top: 5px;
+  padding: 5px;
+}
+
+button {
+  margin-top: 10px;
+  padding: 5px 10px;
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+}

--- a/src/main/scala/community/LoginController.scala
+++ b/src/main/scala/community/LoginController.scala
@@ -9,11 +9,7 @@ import javafx.stage.Stage
 class LoginController {
   @FXML private var emailField: TextField = _
 
-  private val users: Map[String, User] = Map(
-    "farmer@example.com" -> new Farmer("Farmer Joe", "farmer@example.com"),
-    "volunteer@example.com" -> new Volunteer("Volunteer Bob", "volunteer@example.com"),
-    "leader@example.com" -> new CommunityLeader("Leader Alice", "leader@example.com")
-  )
+  private val users = UserRegistry.users
 
   @FXML
   def handleLogin(): Unit = {
@@ -28,5 +24,12 @@ class LoginController {
       case None =>
         println("Invalid user")
     }
+  }
+
+  @FXML
+  def handleShowSignup(): Unit = {
+    val stage = emailField.getScene.getWindow.asInstanceOf[Stage]
+    val root = FXMLLoader.load(getClass.getResource("/signup.fxml"))
+    stage.setScene(new Scene(root))
   }
 }

--- a/src/main/scala/community/SignupController.scala
+++ b/src/main/scala/community/SignupController.scala
@@ -1,0 +1,36 @@
+package community
+
+import javafx.fxml.FXML
+import javafx.scene.control.TextField
+import javafx.fxml.FXMLLoader
+import javafx.scene.Scene
+import javafx.stage.Stage
+
+class SignupController {
+  @FXML private var nameField: TextField = _
+  @FXML private var emailField: TextField = _
+
+  @FXML
+  def handleSignup(): Unit = {
+    val name = nameField.getText
+    val email = emailField.getText
+    if (name.nonEmpty && email.nonEmpty) {
+      val newUser = new Volunteer(name, email)
+      UserRegistry.users(email) = newUser
+      Session.currentUser = Some(newUser)
+      val stage = nameField.getScene.getWindow.asInstanceOf[Stage]
+      val root = FXMLLoader.load(getClass.getResource("/dashboard.fxml"))
+      stage.setScene(new Scene(root))
+    } else {
+      println("Please enter name and email")
+    }
+  }
+
+  @FXML
+  def handleBack(): Unit = {
+    val stage = nameField.getScene.getWindow.asInstanceOf[Stage]
+    val root = FXMLLoader.load(getClass.getResource("/login.fxml"))
+    stage.setScene(new Scene(root))
+  }
+}
+

--- a/src/main/scala/community/UserRegistry.scala
+++ b/src/main/scala/community/UserRegistry.scala
@@ -1,0 +1,12 @@
+package community
+
+import scala.collection.mutable
+
+object UserRegistry {
+  val users: mutable.Map[String, User] = mutable.Map(
+    "farmer@example.com" -> new Farmer("Farmer Joe", "farmer@example.com"),
+    "volunteer@example.com" -> new Volunteer("Volunteer Bob", "volunteer@example.com"),
+    "leader@example.com" -> new CommunityLeader("Leader Alice", "leader@example.com")
+  )
+}
+


### PR DESCRIPTION
## Summary
- centralize user storage in UserRegistry
- add signup controller and view with navigation from login
- include basic CSS styling and sample HTML signup page

## Testing
- `sbt compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68980daf34c083278527b46ca5e9eabc